### PR TITLE
Refine home services layout and add booking CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
         <h2>Choose the finish that matches your aesthetic.</h2>
       </div>
       <article class="stack-card reveal-on-scroll">
-        <img src="https://images.unsplash.com/photo-1526045478516-99145907023c?auto=format&fit=crop&w=1800&q=80" alt="Microblading results">
+        <img loading="lazy" src="https://images.unsplash.com/photo-1526045478516-99145907023c?auto=format&fit=crop&w=1800&q=80" alt="Microblading results">
         <div class="stack-copy">
           <p class="eyebrow">Microblading</p>
           <h3>Feather-light definition that stays.</h3>
@@ -78,7 +78,7 @@
         </div>
       </article>
       <article class="stack-card reveal-on-scroll">
-        <img src="https://images.unsplash.com/photo-1600180758890-6b94519a8ba2?auto=format&fit=crop&w=1800&q=80" alt="Brow lamination result">
+        <img loading="lazy" src="https://images.unsplash.com/photo-1600180758890-6b94519a8ba2?auto=format&fit=crop&w=1800&q=80" alt="Brow lamination result">
         <div class="stack-copy">
           <p class="eyebrow">Brow Lamination</p>
           <h3>Sculpted lift with a brushed-up finish.</h3>
@@ -87,7 +87,7 @@
         </div>
       </article>
       <article class="stack-card reveal-on-scroll">
-        <img src="https://images.unsplash.com/photo-1594747458001-e9456d1c77f8?auto=format&fit=crop&w=1800&q=80" alt="Classic lash extensions">
+        <img loading="lazy" src="https://images.unsplash.com/photo-1594747458001-e9456d1c77f8?auto=format&fit=crop&w=1800&q=80" alt="Classic lash extensions">
         <div class="stack-copy">
           <p class="eyebrow">Classic Lashes</p>
           <h3>Effortless enhancement for the everyday.</h3>
@@ -95,6 +95,9 @@
           <a class="stack-link" href="pmu.html">See All Enhancements</a>
         </div>
       </article>
+      <div class="full-width-cta reveal-on-scroll">
+        <a class="btn btn-dark btn-wide" href="booking.html">Book Your Service</a>
+      </div>
     </section>
 
     <section class="studio" id="studio">
@@ -117,8 +120,9 @@
         <p>Minimal maintenance. Maximum confidence.</p>
       </div>
       <div class="result-gallery">
-        <img class="reveal-on-scroll" src="https://images.unsplash.com/photo-1596462502278-27bfdc403348?auto=format&fit=crop&w=1200&q=80" alt="Before and after comparison">
-        <img class="reveal-on-scroll" src="https://images.unsplash.com/photo-1531297484001-80022131f5a1?auto=format&fit=crop&w=1200&q=80" alt="Detail of perfected brows">
+        <img class="reveal-on-scroll" loading="lazy" src="https://images.unsplash.com/photo-1596462502278-27bfdc403348?auto=format&fit=crop&w=1200&q=80" alt="Before and after comparison">
+        <img class="reveal-on-scroll" loading="lazy" src="https://images.unsplash.com/photo-1531297484001-80022131f5a1?auto=format&fit=crop&w=1200&q=80" alt="Detail of perfected brows">
+        <img class="reveal-on-scroll" loading="lazy" src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=1200&q=80" alt="Client showcasing full brows">
       </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@
   --white: #ffffff;
   --radius-lg: 32px;
   --radius-md: 18px;
-  --max-width: 1200px;
+  --max-width: 1100px;
 }
 
 * {
@@ -236,21 +236,26 @@ p {
   display: flex;
   flex-direction: column;
   gap: 64px;
+  align-items: center;
 }
 
 .stack-card {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 48px;
   align-items: center;
-  max-width: var(--max-width);
+  max-width: min(var(--max-width), 1000px);
   margin: 0 auto;
-  padding: 0 5vw;
+  padding: 32px 5vw;
+  background: var(--white);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 20px 60px rgba(17, 17, 17, 0.05);
 }
 
 .stack-card img {
   width: 100%;
-  height: 420px;
+  height: 100%;
+  max-height: 420px;
   object-fit: cover;
   border-radius: var(--radius-lg);
   box-shadow: 0 24px 60px rgba(17, 17, 17, 0.08);
@@ -310,6 +315,7 @@ p {
   margin: 72px auto 0;
   display: grid;
   gap: 32px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .result-gallery img {
@@ -318,6 +324,36 @@ p {
   height: 480px;
   border-radius: var(--radius-lg);
   box-shadow: 0 24px 60px rgba(17, 17, 17, 0.08);
+}
+
+.full-width-cta {
+  width: 100%;
+  padding: 0 5vw;
+  display: flex;
+  justify-content: center;
+}
+
+.btn-wide {
+  width: min(100%, 420px);
+  padding: 18px 32px;
+  font-size: 1.1rem;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 18px 40px rgba(17, 17, 17, 0.12);
+}
+
+@media (max-width: 768px) {
+  .stack-card {
+    padding: 24px;
+    gap: 32px;
+  }
+
+  .stack-card img {
+    max-height: 320px;
+  }
+
+  .btn-wide {
+    width: 100%;
+  }
 }
 
 .booking {


### PR DESCRIPTION
## Summary
- tighten the services section layout so copy and imagery sit within a narrower card
- add a wide booking call-to-action button and improve testimonial gallery coverage
- apply lazy loading and layout tweaks for image consistency across the homepage

## Testing
- node server.js (manually viewed homepage)


------
https://chatgpt.com/codex/tasks/task_e_690b8caf204c833289e69218d3383369