### PR TITLE
Create dedicated glassmorphic services page

### DIFF
--- a/booking.html
+++ b/booking.html
@@ -12,11 +12,13 @@
 </head>
 <body>
   <header class="site-header">
-    <div class="logo">Woods Brows</div>
-    <nav class="nav">
-      <a href="index.html#services">Services</a>
-      <a href="booking.html" class="btn">Book Now</a>
-    </nav>
+    <div class="nav-shell">
+      <a href="index.html" class="logo">Woods Brows</a>
+      <nav class="nav">
+        <a href="services.html">Services</a>
+        <a href="booking.html" class="btn">Book Now</a>
+      </nav>
+    </div>
   </header>
 
   <section class="booking">

--- a/brow-lamination.html
+++ b/brow-lamination.html
@@ -11,11 +11,13 @@
 </head>
 <body>
   <header class="site-header">
-    <div class="logo">Woods Brows</div>
-    <nav class="nav">
-      <a href="index.html#services">Services</a>
-      <a href="booking.html" class="btn">Book Now</a>
-    </nav>
+    <div class="nav-shell">
+      <a href="index.html" class="logo">Woods Brows</a>
+      <nav class="nav">
+        <a href="services.html">Services</a>
+        <a href="booking.html" class="btn">Book Now</a>
+      </nav>
+    </div>
   </header>
 
   <section class="service-detail">

--- a/facials.html
+++ b/facials.html
@@ -11,11 +11,13 @@
 </head>
 <body>
   <header class="site-header">
-    <div class="logo">Woods Brows</div>
-    <nav class="nav">
-      <a href="index.html#services">Services</a>
-      <a href="booking.html" class="btn">Book Now</a>
-    </nav>
+    <div class="nav-shell">
+      <a href="index.html" class="logo">Woods Brows</a>
+      <nav class="nav">
+        <a href="services.html">Services</a>
+        <a href="booking.html" class="btn">Book Now</a>
+      </nav>
+    </div>
   </header>
 
   <section class="service-detail">

--- a/index.html
+++ b/index.html
@@ -15,10 +15,10 @@
     <div class="nav-shell">
       <a href="#top" class="logo">Woods Brows</a>
       <nav class="nav">
-        <a href="#services">Services</a>
+        <a href="services.html">Services</a>
         <a href="#studio">Studio</a>
         <a href="#booking">Booking</a>
-        <a href="booking.html" class="btn btn-dark">Book Now</a>
+        <a href="booking.html" class="btn">Book Now</a>
       </nav>
     </div>
   </header>
@@ -31,7 +31,7 @@
           <p>Luxury brow artistry inspired by modern architecture—minimal, sculptural, and designed around you.</p>
           <div class="cta-row">
             <a href="#booking" class="btn">Book a Consultation</a>
-            <a href="#services" class="link">Explore Services</a>
+            <a href="services.html" class="link">Explore Services</a>
           </div>
         </div>
         <figure class="hero-visual">
@@ -63,38 +63,29 @@
       </div>
     </section>
 
-    <section class="service-stack" id="services">
+    <section class="gateway" aria-labelledby="gateway-title">
       <div class="section-intro">
-        <p class="eyebrow">Services</p>
-        <h2>Choose the finish that matches your aesthetic.</h2>
+        <p class="eyebrow" id="gateway-title">Next Steps</p>
+        <h2>Step into the studio or explore every finish in detail.</h2>
       </div>
-      <article class="stack-card reveal-on-scroll">
-        <img src="https://images.unsplash.com/photo-1526045478516-99145907023c?auto=format&fit=crop&w=1800&q=80" alt="Microblading results">
-        <div class="stack-copy">
-          <p class="eyebrow">Microblading</p>
-          <h3>Feather-light definition that stays.</h3>
-          <p>Ultra-fine hairstrokes laid with precision for full, natural dimension. Ideal for sparse brows or clients wanting lasting polish.</p>
-          <a class="stack-link" href="microblading.html">Discover Microblading</a>
-        </div>
-      </article>
-      <article class="stack-card reveal-on-scroll">
-        <img src="https://images.unsplash.com/photo-1600180758890-6b94519a8ba2?auto=format&fit=crop&w=1800&q=80" alt="Brow lamination result">
-        <div class="stack-copy">
-          <p class="eyebrow">Brow Lamination</p>
-          <h3>Sculpted lift with a brushed-up finish.</h3>
-          <p>Polish unruly hairs into a smooth, airy silhouette with gentle lamination and nourishing aftercare guidance.</p>
-          <a class="stack-link" href="brow-lamination.html">Explore Lamination</a>
-        </div>
-      </article>
-      <article class="stack-card reveal-on-scroll">
-        <img src="https://images.unsplash.com/photo-1594747458001-e9456d1c77f8?auto=format&fit=crop&w=1800&q=80" alt="Classic lash extensions">
-        <div class="stack-copy">
-          <p class="eyebrow">Classic Lashes</p>
-          <h3>Effortless enhancement for the everyday.</h3>
-          <p>Lightweight single lashes applied for clean, timeless definition—perfect for low-maintenance mornings.</p>
-          <a class="stack-link" href="pmu.html">See All Enhancements</a>
-        </div>
-      </article>
+      <div class="gateway-grid">
+        <a class="glass-tile reveal-on-scroll" href="services.html">
+          <div class="tile-content">
+            <span class="tile-kicker">Effortless Brows</span>
+            <h3>See every service</h3>
+            <p>Dive into our menu with Apple-inspired glass layouts, close-up imagery, and tailored recommendations.</p>
+            <span class="tile-link">View Services →</span>
+          </div>
+        </a>
+        <a class="glass-tile reveal-on-scroll" href="booking.html">
+          <div class="tile-content">
+            <span class="tile-kicker">Reserve Your Seat</span>
+            <h3>Book now</h3>
+            <p>Secure your appointment in seconds with our liquid-glass booking experience designed for calm clarity.</p>
+            <span class="tile-link">Book an Appointment →</span>
+          </div>
+        </a>
+      </div>
     </section>
 
     <section class="studio" id="studio">
@@ -117,8 +108,9 @@
         <p>Minimal maintenance. Maximum confidence.</p>
       </div>
       <div class="result-gallery">
-        <img class="reveal-on-scroll" src="https://images.unsplash.com/photo-1596462502278-27bfdc403348?auto=format&fit=crop&w=1200&q=80" alt="Before and after comparison">
-        <img class="reveal-on-scroll" src="https://images.unsplash.com/photo-1531297484001-80022131f5a1?auto=format&fit=crop&w=1200&q=80" alt="Detail of perfected brows">
+        <img class="reveal-on-scroll" loading="lazy" src="https://images.unsplash.com/photo-1596462502278-27bfdc403348?auto=format&fit=crop&w=1200&q=80" alt="Before and after comparison">
+        <img class="reveal-on-scroll" loading="lazy" src="https://images.unsplash.com/photo-1531297484001-80022131f5a1?auto=format&fit=crop&w=1200&q=80" alt="Detail of perfected brows">
+        <img class="reveal-on-scroll" loading="lazy" src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=1200&q=80" alt="Client showcasing full brows">
       </div>
     </section>
 

--- a/microblading.html
+++ b/microblading.html
@@ -11,11 +11,13 @@
 </head>
 <body>
   <header class="site-header">
-    <div class="logo">Woods Brows</div>
-    <nav class="nav">
-      <a href="index.html#services">Services</a>
-      <a href="booking.html" class="btn">Book Now</a>
-    </nav>
+    <div class="nav-shell">
+      <a href="index.html" class="logo">Woods Brows</a>
+      <nav class="nav">
+        <a href="services.html">Services</a>
+        <a href="booking.html" class="btn">Book Now</a>
+      </nav>
+    </div>
   </header>
 
   <section class="service-detail">

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-
+    "check:conflicts": "node scripts/check-conflicts.mjs"
   },
   "dependencies": {
     "dotenv": "^16.4.0",

--- a/pmu.html
+++ b/pmu.html
@@ -11,11 +11,13 @@
 </head>
 <body>
   <header class="site-header">
-    <div class="logo">Woods Brows</div>
-    <nav class="nav">
-      <a href="index.html#services">Services</a>
-      <a href="booking.html" class="btn">Book Now</a>
-    </nav>
+    <div class="nav-shell">
+      <a href="index.html" class="logo">Woods Brows</a>
+      <nav class="nav">
+        <a href="services.html">Services</a>
+        <a href="booking.html" class="btn">Book Now</a>
+      </nav>
+    </div>
   </header>
 
   <section class="service-detail">

--- a/scripts/check-conflicts.mjs
+++ b/scripts/check-conflicts.mjs
@@ -1,0 +1,37 @@
+import { readdir, readFile } from 'fs/promises';
+import { join } from 'path';
+
+const conflictMarkers = ['<<' + '<<<<<', '='.repeat(7), '>>' + '>>>>'];
+
+async function walk(dir, ignore = new Set(['.git', 'node_modules'])) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (ignore.has(entry.name)) continue;
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await walk(fullPath, ignore));
+    } else {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+let hasConflicts = false;
+const files = await walk('.');
+
+for (const file of files) {
+  const contents = await readFile(file, 'utf8');
+  if (conflictMarkers.some(marker => contents.includes(marker))) {
+    hasConflicts = true;
+    console.error(`Conflict marker found in ${file}`);
+  }
+}
+
+if (hasConflicts) {
+  console.error('\nResolve the conflicts before continuing.');
+  process.exitCode = 1;
+} else {
+  console.log('No merge conflict markers detected.');
+}

--- a/services.html
+++ b/services.html
@@ -71,37 +71,36 @@
       </article>
     </section>
 
-    <section class="services-callout">
+    <section class="services-highlights">
       <div class="glass-panel reveal-on-scroll">
-        <h2>If you want it to feel even more Apple-authentic…</h2>
-        <p>We can produce elevated variations that dial up the visionOS glass aesthetic.</p>
-        <ul class="callout-list">
-          <li>Deeper blur / glow edges</li>
-          <li>More transparency</li>
-          <li>Holographic accent lighting</li>
-          <li>Option to add Book Now CTA buttons</li>
-          <li>Separate mobile versions optimized for scrolling</li>
-          <li>Hero background video overlay (your lash studio b-roll behind the glass 👀🔥)</li>
-        </ul>
-        <p class="callout-footnote">Ready for more? Ask for booking buttons, a before/after gallery, price menu, or even animated liquid-glass intros tailored for reels.</p>
+        <p class="eyebrow">Why clients stay loyal</p>
+        <h2>Artistry that feels as seamless as it looks</h2>
+        <div class="services-highlights-grid">
+          <div class="highlight-card">
+            <h3>Consultative design</h3>
+            <p>Every appointment begins with precise mapping and a discussion of how you live, ensuring the finish looks effortless on day one and day one hundred.</p>
+          </div>
+          <div class="highlight-card">
+            <h3>Skin-first comfort</h3>
+            <p>Low-sensitising pigments, gentle pressure, and calming aftercare keep the experience soothing from prep to reveal.</p>
+          </div>
+          <div class="highlight-card">
+            <h3>Modern luxury</h3>
+            <p>Glass-inspired UI extends to the studio experience—minimal, calming touches and meticulously curated playlists set the tone.</p>
+          </div>
+        </div>
       </div>
     </section>
 
-    <section class="services-followup">
+    <section class="services-cta">
       <div class="glass-panel reveal-on-scroll">
-        <p class="eyebrow">What to request next</p>
-        <h2>Curate the full Apple glass toolkit</h2>
-        <p>Select any add-on and we’ll craft it to match this liquid-glass system:</p>
-        <ul class="callout-list">
-          <li>Homepage hero section (Apple landing page style)</li>
-          <li>Before / After gallery in liquid glass frames</li>
-          <li>Price menu version</li>
-          <li>Animated liquid-glass intro for TikTok / Reel</li>
-          <li>Navigation header + footer UI</li>
-          <li>Booking buttons in glass UI</li>
-          <li>Mobile menu w/ glass pull-up drawer</li>
-          <li>Lash/Brow icons matching VisionOS style</li>
-        </ul>
+        <p class="eyebrow">Ready to elevate</p>
+        <h2>Reserve your signature finish</h2>
+        <p>Choose your service, select a time that suits your schedule, and arrive to a private studio prepared just for you.</p>
+        <div class="cta-row">
+          <a class="btn" href="booking.html">Book Now</a>
+          <a class="link" href="index.html#studio">Tour the studio →</a>
+        </div>
       </div>
     </section>
   </main>

--- a/services.html
+++ b/services.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Services - Woods Brows</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="services">
+  <header class="site-header">
+    <div class="nav-shell">
+      <a href="index.html" class="logo">Woods Brows</a>
+      <nav class="nav">
+        <a href="services.html" class="active">Services</a>
+        <a href="booking.html" class="btn">Book Now</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="services-hero">
+      <div class="glass-banner reveal-on-scroll">
+        <p class="eyebrow">Signature Menu</p>
+        <h1>Effortlessly beautiful</h1>
+        <p>Minimalist, liquid-glass inspired treatments that elevate your natural features while feeling unmistakably modern.</p>
+      </div>
+    </section>
+
+    <section class="service-showcase">
+      <article class="service-card glass-panel reveal-on-scroll">
+        <div class="service-card-media">
+          <img loading="lazy" src="https://images.unsplash.com/photo-1526045478516-99145907023c?auto=format&fit=crop&w=1400&q=80" alt="Microblading service result">
+        </div>
+        <div class="service-card-copy">
+          <h2>Microblading</h2>
+          <p>Soft, natural, and tailored to your bone structure. Microblading uses ultra fine strokes that mimic real hair, bringing balance with a hyper-realistic finish.</p>
+          <ul>
+            <li>Perfect for: sparse brows, busy schedules, low-maintenance beauty</li>
+            <li>Duration: 2.5 hours</li>
+            <li>Longevity: 12–18 months</li>
+            <li>Healing: Soft peel in 7–10 days</li>
+          </ul>
+          <div class="card-actions">
+            <a class="btn" href="booking.html">Book Microblading</a>
+            <a class="link" href="microblading.html">Learn more →</a>
+          </div>
+        </div>
+      </article>
+
+      <article class="service-card glass-panel reveal-on-scroll">
+        <div class="service-card-media">
+          <img loading="lazy" src="https://images.unsplash.com/photo-1594747458001-e9456d1c77f8?auto=format&fit=crop&w=1400&q=80" alt="Lash extensions styling">
+        </div>
+        <div class="service-card-copy">
+          <h2>Lash Extensions</h2>
+          <p>Custom-designed lashes that enhance your natural eye shape. Lightweight sets keep wear comfortable while delivering long-lasting refinement.</p>
+          <ul>
+            <li>Styles: Classic, Hybrid, Light Volume</li>
+            <li>Full set: 2 hours • Fills: every 2–3 weeks</li>
+            <li>Finish: soft, airy, and weightless</li>
+            <li>Includes: lash cleanse, styling, and aftercare guidance</li>
+          </ul>
+          <div class="card-actions">
+            <a class="btn" href="booking.html">Book Lash Extensions</a>
+            <a class="link" href="pmu.html">See enhancement details →</a>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <section class="services-callout">
+      <div class="glass-panel reveal-on-scroll">
+        <h2>If you want it to feel even more Apple-authentic…</h2>
+        <p>We can produce elevated variations that dial up the visionOS glass aesthetic.</p>
+        <ul class="callout-list">
+          <li>Deeper blur / glow edges</li>
+          <li>More transparency</li>
+          <li>Holographic accent lighting</li>
+          <li>Option to add Book Now CTA buttons</li>
+          <li>Separate mobile versions optimized for scrolling</li>
+          <li>Hero background video overlay (your lash studio b-roll behind the glass 👀🔥)</li>
+        </ul>
+        <p class="callout-footnote">Ready for more? Ask for booking buttons, a before/after gallery, price menu, or even animated liquid-glass intros tailored for reels.</p>
+      </div>
+    </section>
+
+    <section class="services-followup">
+      <div class="glass-panel reveal-on-scroll">
+        <p class="eyebrow">What to request next</p>
+        <h2>Curate the full Apple glass toolkit</h2>
+        <p>Select any add-on and we’ll craft it to match this liquid-glass system:</p>
+        <ul class="callout-list">
+          <li>Homepage hero section (Apple landing page style)</li>
+          <li>Before / After gallery in liquid glass frames</li>
+          <li>Price menu version</li>
+          <li>Animated liquid-glass intro for TikTok / Reel</li>
+          <li>Navigation header + footer UI</li>
+          <li>Booking buttons in glass UI</li>
+          <li>Mobile menu w/ glass pull-up drawer</li>
+          <li>Lash/Brow icons matching VisionOS style</li>
+        </ul>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="footer-shell">
+      <p>© Woods Brows. Everett, WA.</p>
+      <div class="footer-links">
+        <a href="index.html#studio">Studio</a>
+        <a href="booking.html">Book Now</a>
+        <a href="https://instagram.com" target="_blank" rel="noopener">Instagram</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="main.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -4,9 +4,12 @@
   --linen: #f8f7f4;
   --shell: #f1f0ed;
   --white: #ffffff;
+  --glass-border: rgba(255, 255, 255, 0.65);
+  --glass-shadow: rgba(15, 23, 42, 0.18);
+  --glass-sheen: rgba(255, 255, 255, 0.35);
   --radius-lg: 32px;
   --radius-md: 18px;
-  --max-width: 1200px;
+  --max-width: 1100px;
 }
 
 * {
@@ -23,6 +26,10 @@ body {
   background: var(--white);
   color: var(--ink);
   line-height: 1.6;
+}
+
+body.services {
+  background: linear-gradient(180deg, #f4f5f8 0%, #ffffff 45%, #f6f3ef 100%);
 }
 
 main {
@@ -84,6 +91,7 @@ p {
 .nav {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 28px;
   font-size: 0.95rem;
 }
@@ -114,21 +122,27 @@ p {
   justify-content: center;
   gap: 0.5rem;
   border-radius: 999px;
-  padding: 12px 22px;
+  padding: 12px 26px;
   font-weight: 600;
-  background: var(--ink);
-  color: var(--white);
-  transition: transform 0.2s ease, background 0.2s ease;
+  color: var(--ink);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0.2));
+  border: 1px solid rgba(17, 17, 17, 0.08);
+  box-shadow: 0 20px 45px -18px var(--glass-shadow), inset 0 1px 0 var(--glass-sheen);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .btn:hover {
-  transform: translateY(-1px);
-  background: rgba(17, 17, 17, 0.9);
+  transform: translateY(-2px);
+  box-shadow: 0 26px 55px -16px rgba(15, 23, 42, 0.26);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.28));
 }
 
 .btn-dark {
-  background: var(--ink);
+  background: rgba(17, 17, 17, 0.88);
   color: var(--white);
+  border-color: transparent;
 }
 
 .link {
@@ -139,6 +153,11 @@ p {
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 6px;
+}
+
+.nav a.active {
+  color: var(--ink);
+  font-weight: 600;
 }
 
 .hero {
@@ -212,6 +231,71 @@ p {
   padding: 100px 5vw 120px;
 }
 
+.gateway {
+  padding: 120px 5vw 140px;
+  background: radial-gradient(circle at top left, rgba(241, 240, 237, 0.45), transparent 55%), var(--white);
+}
+
+.gateway-grid {
+  max-width: var(--max-width);
+  margin: 80px auto 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 32px;
+}
+
+.glass-tile {
+  position: relative;
+  display: block;
+  padding: 48px 42px;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.18));
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  box-shadow: 0 32px 60px -30px var(--glass-shadow), inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  backdrop-filter: blur(26px);
+  -webkit-backdrop-filter: blur(26px);
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.glass-tile::after {
+  content: '';
+  position: absolute;
+  inset: 12px 40% auto 12px;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0));
+}
+
+.glass-tile:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 45px 90px -36px rgba(15, 23, 42, 0.3);
+}
+
+.tile-content {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-height: 220px;
+}
+
+.tile-content h3 {
+  font-size: clamp(1.9rem, 4vw, 2.4rem);
+}
+
+.tile-kicker {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  color: rgba(17, 17, 17, 0.5);
+}
+
+.tile-link {
+  margin-top: auto;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 6px;
+}
+
 .value-grid {
   max-width: var(--max-width);
   margin: 72px auto 0;
@@ -229,49 +313,6 @@ p {
   flex-direction: column;
   gap: 16px;
   text-align: left;
-}
-
-.service-stack {
-  padding: 120px 0;
-  display: flex;
-  flex-direction: column;
-  gap: 64px;
-}
-
-.stack-card {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 48px;
-  align-items: center;
-  max-width: var(--max-width);
-  margin: 0 auto;
-  padding: 0 5vw;
-}
-
-.stack-card img {
-  width: 100%;
-  height: 420px;
-  object-fit: cover;
-  border-radius: var(--radius-lg);
-  box-shadow: 0 24px 60px rgba(17, 17, 17, 0.08);
-}
-
-.stack-copy {
-  max-width: 420px;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-}
-
-.stack-copy h3 {
-  font-size: clamp(1.8rem, 3vw, 2.6rem);
-}
-
-.stack-link {
-  font-weight: 600;
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 6px;
 }
 
 .studio {
@@ -310,6 +351,7 @@ p {
   margin: 72px auto 0;
   display: grid;
   gap: 32px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .result-gallery img {
@@ -318,6 +360,115 @@ p {
   height: 480px;
   border-radius: var(--radius-lg);
   box-shadow: 0 24px 60px rgba(17, 17, 17, 0.08);
+}
+
+.glass-panel {
+  position: relative;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.25));
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow: 0 40px 70px -32px rgba(15, 23, 42, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(28px);
+  -webkit-backdrop-filter: blur(28px);
+}
+
+.glass-banner {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 72px 48px;
+  text-align: center;
+}
+
+.services-hero {
+  padding: 160px 5vw 80px;
+  background: radial-gradient(circle at 20% 20%, rgba(241, 240, 237, 0.6), transparent 55%), var(--white);
+}
+
+.service-showcase {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 40px 5vw 80px;
+  display: grid;
+  gap: 48px;
+}
+
+.service-card {
+  display: grid;
+  gap: 32px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: stretch;
+  padding: 48px;
+}
+
+.service-card-media img {
+  width: 100%;
+  height: 100%;
+  min-height: 280px;
+  object-fit: cover;
+  border-radius: calc(var(--radius-lg) - 12px);
+  box-shadow: 0 32px 60px -30px rgba(15, 23, 42, 0.28);
+}
+
+.service-card-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.service-card-copy h2 {
+  font-size: clamp(2.4rem, 4vw, 3rem);
+}
+
+.service-card-copy ul {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--soft-ink);
+  list-style: disc;
+}
+
+.service-card-copy ul li + li {
+  margin-top: 10px;
+}
+
+.card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 10px;
+}
+
+.services-callout,
+.services-followup {
+  padding: 60px 5vw 0;
+}
+
+.services-callout .glass-panel,
+.services-followup .glass-panel {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 56px 48px;
+  display: grid;
+  gap: 24px;
+}
+
+.callout-list {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--soft-ink);
+  list-style: disc;
+}
+
+.callout-list li + li {
+  margin-top: 12px;
+}
+
+.callout-footnote {
+  font-size: 0.9rem;
+  color: rgba(17, 17, 17, 0.55);
+}
+
+.services-followup {
+  padding-bottom: 120px;
 }
 
 .booking {
@@ -432,34 +583,44 @@ p {
 }
 
 @media (max-width: 900px) {
-  .nav {
-    display: none;
+  .nav-shell {
+    padding: 18px 24px;
+    gap: 18px;
   }
 
-  .nav-shell {
-    justify-content: center;
+  .nav {
+    gap: 18px;
   }
 
   main {
-    padding-top: 80px;
+    padding-top: 108px;
   }
 
   .hero {
-    padding-top: 120px;
+    padding-top: 140px;
   }
 
-  .stack-card img {
-    height: 320px;
+  .glass-tile {
+    padding: 40px 32px;
+  }
+
+  .service-card {
+    padding: 36px;
+  }
+
+  .services-callout .glass-panel,
+  .services-followup .glass-panel {
+    padding: 44px 32px;
   }
 
   .studio-visual img {
-    min-height: 320px;
+    min-height: 360px;
   }
 }
 
 @media (max-width: 640px) {
   .hero {
-    padding: 100px 24px 120px;
+    padding: 110px 24px 120px;
   }
 
   .hero-inner {
@@ -476,6 +637,23 @@ p {
 
   .value-tile {
     padding: 28px;
+  }
+
+  .glass-banner {
+    padding: 56px 32px;
+  }
+
+  .service-card {
+    padding: 28px;
+  }
+
+  .card-actions {
+    justify-content: center;
+  }
+
+  .services-callout .glass-panel,
+  .services-followup .glass-panel {
+    padding: 36px 26px;
   }
 
   #calendar {

--- a/style.css
+++ b/style.css
@@ -437,38 +437,50 @@ p {
   margin-top: 10px;
 }
 
-.services-callout,
-.services-followup {
+.services-highlights,
+.services-cta {
   padding: 60px 5vw 0;
 }
 
-.services-callout .glass-panel,
-.services-followup .glass-panel {
+.services-highlights .glass-panel,
+.services-cta .glass-panel {
   max-width: 1100px;
   margin: 0 auto;
   padding: 56px 48px;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 24px;
 }
 
-.callout-list {
-  margin: 0;
-  padding-left: 20px;
+.services-highlights-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.highlight-card {
+  padding: 24px;
+  border-radius: calc(var(--radius-lg) - 12px);
+  background: rgba(255, 255, 255, 0.6);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
   color: var(--soft-ink);
-  list-style: disc;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.callout-list li + li {
-  margin-top: 12px;
+.highlight-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-weight: 500;
+  color: var(--ink);
 }
 
-.callout-footnote {
-  font-size: 0.9rem;
-  color: rgba(17, 17, 17, 0.55);
-}
-
-.services-followup {
+.services-cta {
   padding-bottom: 120px;
+}
+
+.services-cta .cta-row {
+  margin-top: 0;
 }
 
 .booking {
@@ -608,8 +620,8 @@ p {
     padding: 36px;
   }
 
-  .services-callout .glass-panel,
-  .services-followup .glass-panel {
+  .services-highlights .glass-panel,
+  .services-cta .glass-panel {
     padding: 44px 32px;
   }
 
@@ -651,8 +663,8 @@ p {
     justify-content: center;
   }
 
-  .services-callout .glass-panel,
-  .services-followup .glass-panel {
+  .services-highlights .glass-panel,
+  .services-cta .glass-panel {
     padding: 36px 26px;
   }
 


### PR DESCRIPTION
## Summary
- replace the homepage services list with glass CTA tiles that redirect to the booking and services destinations
- build a dedicated services.html experience with the "Effortlessly beautiful" tagline, two core offerings, and Apple-inspired glass callouts
- refresh button styling and subpage navigation so every page points to the new services hub while adopting the glass UI aesthetic

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_690b8caf204c833289e69218d3383369